### PR TITLE
fixed awakefromnib

### DIFF
--- a/Example/ContextMenu/ContextMenuCell/ContextMenuCell.m
+++ b/Example/ContextMenu/ContextMenuCell/ContextMenuCell.m
@@ -15,6 +15,7 @@
 @implementation ContextMenuCell
 
 - (void)awakeFromNib {
+    [super awakeFromNib];
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     self.layer.masksToBounds = YES;
     self.layer.shadowOffset = CGSizeMake(0, 2);

--- a/Example/ContextMenu/ViewController.m
+++ b/Example/ContextMenu/ViewController.m
@@ -109,7 +109,7 @@ static NSString *const menuCellIdentifier = @"rotationCell";
 
 #pragma mark - YALContextMenuTableViewDelegate
 
-- (void)didDismissWithIndexPath:(NSIndexPath*)indexPath {
+- (void)contextMenuTableView:(YALContextMenuTableView *)contextMenuTableView didDismissWithIndexPath:(NSIndexPath *)indexPath{
     NSLog(@"Menu dismissed with indexpath = %@", indexPath);
 }
 


### PR DESCRIPTION
According to the Apple's document for -(void)awakeFromNib, we should always call [super awakeFromNib];
