### PR TITLE
fix in 1 line of code

### DIFF
--- a/YALContextMenu/YALContextMenuTableView.m
+++ b/YALContextMenu/YALContextMenuTableView.m
@@ -133,6 +133,7 @@ typedef NS_ENUM(NSUInteger, AnimatingState) {
     
     [self dismissTopCells];
     [self dismissBottomCells];
+    [self shouldDismissSelf];
 }
 
 


### PR DESCRIPTION
Why do we have to check if arrays are empty if it's already done in 'shouldDismiss' method.
